### PR TITLE
Just a better workflow

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: nocturlab/setup-vlang-action@v1
       with:
-        v-version: master
+        v-version: latest
     - name: Build boundstone
       run: v boundstone.v
     - name: Run boundstone

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -3,28 +3,20 @@ name: CI
 on: [push]
 
 jobs:
-  build_from_latest_v_release:
-
-    runs-on: ubuntu-latest
-    
+  builde:
+    name: Build using V ${{ matrix.v_version }}
+    runs-on: 
+      - ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        v_version: [master, latest]
     steps:
     - uses: actions/checkout@v1
     - uses: nocturlab/setup-vlang-action@v1
       with:
-        v-version: latest
-    - name: Build boundstone
-      run: v boundstone.v
-    - name: Run boundstone
-      run: ./boundstone
-      
-  build_from_master_v_branch:
-    runs-on: ubuntu-latest
-    
-    steps:
-    - uses: actions/checkout@v1
-    - uses: nocturlab/setup-vlang-action@v1
-      with:
-        v-version: master
+        v-version: ${{ matrix.v_version }}
     - name: Build boundstone
       run: v boundstone.v
     - name: Run boundstone

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push]
 
 jobs:
-  build:
+  build_from_latest_v_release:
 
     runs-on: ubuntu-latest
     
@@ -12,6 +12,19 @@ jobs:
     - uses: nocturlab/setup-vlang-action@v1
       with:
         v-version: latest
+    - name: Build boundstone
+      run: v boundstone.v
+    - name: Run boundstone
+      run: ./boundstone
+      
+  build_from_master_v_branch:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - uses: nocturlab/setup-vlang-action@v1
+      with:
+        v-version: master
     - name: Build boundstone
       run: v boundstone.v
     - name: Run boundstone

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -9,11 +9,11 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
-    - name: Clone V
-      run: git clone https://github.com/vlang/v
-    - name: Build V
-      run: make -C v
+    - name: Set up V version 0.1.24
+      uses: nocturlab/setup-vlang-action@v1
+      with:
+        v-version: master
     - name: Build boundstone
-      run: ./v/v boundstone.v
+      run: v boundstone.v
     - name: Run boundstone
       run: ./boundstone

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -9,8 +9,7 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
-    - name: Set up V version 0.1.24
-      uses: nocturlab/setup-vlang-action@v1
+    - uses: nocturlab/setup-vlang-action@v1
       with:
         v-version: master
     - name: Build boundstone


### PR DESCRIPTION
This can help you to test workflow on many v version, like the latest release or the current version on master branch.

The `fail-fast`is to false because we want to keep other version running if one fail, because it can show us many changements in v that can break something.